### PR TITLE
Fix 17 dependency issues with auto dependency generation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,6 +3,7 @@ CSRC = $(wildcard *.c) $(wildcard */*.c) $(wildcard */*/*.c)
 
 SOURCES = $(CSRC:.c=.o) $(ASMSRC:.s=.o)
 BINARY=../bin/kernel
+OBJS = $(CSRC:.c=.o)
 
 CFLAGS=-g -I. -m32 -std=c99 -fno-builtin -fno-stack-protector -lgcc -ffreestanding -Wall -Wextra -fno-exceptions
 LDFLAGS=-melf_i386 -Tlink.ld
@@ -13,9 +14,23 @@ all: $(SOURCES) link
 clean:
 	rm $(BINARY)
 	find . -name "*.o" | xargs rm
+	find . -name "*.d" | xargs rm
 
 link:
 	ld $(LDFLAGS) -o $(BINARY) $(SOURCES)
 
 .s.o:
 	nasm $(ASFLAGS) $<
+
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.o,%.d, $(OBJS))
+
+ # include by auto dependencies
+-include $(AUTODEPS)
+
+%.o: %.c %.d
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.d: %.c
+	$(CC) $(CFLAGS) -MM -MT"$@ $(@:.d=.o)" -MP -MF $@ $<
+

--- a/util/initrd/Makefile
+++ b/util/initrd/Makefile
@@ -8,9 +8,23 @@ all: $(SOURCES) link
 
 clean:
 	-rm *.o
+	-rm $(AUTODEPS)
 
 .cpp:
 	$(CC) -c -o $@ $< $(CFLAGS)
 
-link:
+link: $(SOURCES)
 	$(CC) $(SOURCES) -o $(BINARY) $(LDFLAGS)
+
+%.o: %.cpp %.d
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.d: %.cpp
+	$(CC) $(CFLAGS) -MM -MT"$@ $(@:.d=.o)" -MP -MF $@ $<
+
+# create a list of auto dependencies
+AUTODEPS:= $(patsubst %.o,%.d, $(SOURCES))
+
+ # include by auto dependencies
+-include $(AUTODEPS)
+


### PR DESCRIPTION
Hi Nicolas,

We have found and fixed 17 dependency issues in the Makefile.
Those issues can cause incorrect results when the project is incrementally built.
For example, any changes in a header file will not cause the object file to be rebuilt, which is incorrect.
I've tested it on my computer, the fixed version worked as expected.
Looking forward to your confirmation.

I fix them by using the Auto-Dependency Generation technique mentioned here: http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/

Thanks
Vemake